### PR TITLE
Make sure Opt flags is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,6 +385,13 @@ endif()
 
 target_include_directories(${dobby_output_name} PUBLIC include)
 
+if(COMPILER.Clang)
+  if(NOT DOBBY_DEBUG)
+    target_compile_options(${dobby_output_name}
+        PRIVATE "$<$<CONFIG:RELEASE>:-O3>")
+  endif()
+endif()
+
 if(SYSTEM.Darwin AND GenerateDarwinFramework)
   # set framework property
   set_target_properties(Dobby PROPERTIES


### PR DESCRIPTION
CMake with Android NDK overrides the opt flags that declared with variable. This is the only way to make CMake uses our flags.