### PR TITLE
fix crash[arm64]

### DIFF
--- a/source/UserMode/ExecMemory/code-patch-tool-posix.cc
+++ b/source/UserMode/ExecMemory/code-patch-tool-posix.cc
@@ -5,24 +5,28 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <string.h>
-
 #if !defined(__APPLE__)
 PUBLIC MemoryOperationError CodePatch(void *address, uint8_t *buffer, uint32_t buffer_size) {
 
   int page_size = (int)sysconf(_SC_PAGESIZE);
   uintptr_t page_align_address = ALIGN_FLOOR(address, page_size);
   int offset = (uintptr_t)address - page_align_address;
-
+  uintptr_t page_align_address_for_end = ALIGN_FLOOR(page_align_address + offset + buffer_size, page_size);
 #if defined(__ANDROID__) || defined(__linux__)
 
   // change page permission as rwx
   mprotect((void *)page_align_address, page_size, PROT_READ | PROT_WRITE | PROT_EXEC);
-
+  if(page_align_address_for_end != page_align_address){
+     mprotect((void *)page_align_address_for_end, page_size, PROT_READ | PROT_WRITE | PROT_EXEC);
+  }
   // patch buffer
   memcpy((void *)((addr_t)page_align_address + offset), buffer, buffer_size);
 
   // restore page permission
   mprotect((void *)page_align_address, page_size, PROT_READ | PROT_EXEC);
+  if(page_align_address_for_end != page_align_address){
+      mprotect((void *)page_align_address_for_end, page_size, PROT_READ | PROT_EXEC);
+  }
 #endif
 
   addr_t clear_start_ = (addr_t)page_align_address + offset;


### PR DESCRIPTION
Fix the crash when the function address is near the page boundary.