### PR TITLE
Update Android compile commands

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -49,8 +49,7 @@ python3 scripts/platform_builder.py --platform=linux --arch=all --cmake_dir=$HOM
 ```
 # prepare and download cmake/llvm/ndk
 sh scripts/setup_linux_cross_compile.sh
-sh scripts/setup_linux_cross_compile.sh
-python3 scripts/platform_builder.py --platform=linux --arch=all --cmake_dir=$HOME/opt/cmake-3.20.2 --llvm_dir=$HOME/opt/llvm-14.0.0 --android_ndk_dir=$HOME/opt/ndk-r25b
+python3 scripts/platform_builder.py --platform=android --arch=all --cmake_dir=$HOME/opt/cmake-3.20.2 --llvm_dir=$HOME/opt/llvm-14.0.0 --android_ndk_dir=$HOME/opt/ndk-r25b --library_build_type=shared
 ```
 
 ## Build with CMake


### PR DESCRIPTION
Fix:
1. "sh scripts/setup_linux_cross_compile.sh" have been typed twice
2. change "platform" from linux to android
3. build shared lib, otherwise Android will link error which is caused by fPIC and lacking NDK symbol