### PR TITLE
fix relocation bug for call instructions (x86/x64)

### DIFF
--- a/source/InstructionRelocation/x86/InstructionRelocationX86Shared.cc
+++ b/source/InstructionRelocation/x86/InstructionRelocationX86Shared.cc
@@ -55,7 +55,7 @@ int GenRelocateSingleX86Insn(addr_t curr_orig_ip, addr_t curr_relo_ip, uint8_t *
     uint64_t orig_insn_ref_addr = curr_orig_ip + offset;
 
     // jcc
-    __ Emit8(opcode);
+    __ Emit8(insn.primary_opcode);
     __ Emit8(2);
 
     // jmp

--- a/source/InstructionRelocation/x86/InstructionRelocationX86Shared.cc
+++ b/source/InstructionRelocation/x86/InstructionRelocationX86Shared.cc
@@ -146,11 +146,15 @@ int GenRelocateSingleX86Insn(addr_t curr_orig_ip, addr_t curr_relo_ip, uint8_t *
 
     // jmp *(rip)
     __ Emit8(0xFF);
-    if (insn.primary_opcode == 0xE8)
+    if (insn.primary_opcode == 0xE8) {
       __ Emit8(0x15); // ModR/M: 00 010 101
-    else
+      __ Emit32(2);
+      __ Emit8(0xEB);
+      __ Emit8(0x08);
+    } else {
       __ Emit8(0x25); // ModR/M: 00 100 101
-    __ Emit32(0);
+      __ Emit32(0);
+    }
     __ Emit64(orig_insn_ref_addr);
 #endif
   } else if (insn.primary_opcode >= 0xE0 && insn.primary_opcode <= 0xE2) { // LOOPNZ/LOOPZ/LOOP/JECXZ


### PR DESCRIPTION
There is a bug in the relocation of call instructions when doing inline hooks. Consider the following function prologue in x64 as an example:

```
push r14
push rbx
push rax
call _Z27__bionic_atfork_run_preparev
```

Dobby will try to place a jmp trampoline and consequently overwrite the instruction.
As a result Dobby will relocate `_Z27__bionic_atfork_run_preparev` in the relocation stub.

However, the generated relocation stub looks like this:

```
00007F63B634F000 push r14
00007F63B634F002 push rbx
00007F63B634F003 push rax
00007F63B634F004 call cs:off_7F63B634F00A
00007F63B634F00A off_7F63B634F00A dq offset _Z27__bionic_atfork_run_preparev
00007F63B634F012 jmp cs:off_7F63B634F018
00007F63B634F018 off_7F63B634F018 dq offset loc_7F63B34CC9F9
```

Due to the call at `00007F63B634F004` and the call target being placed at `00007F63B634F00A`, the caller will continue execution at `00007F63B634F00A` when returning from `_Z27__bionic_atfork_run_preparev` leading to a crash/undefined behaviour.


I modified `InstructionRelocationX86Shared.cc` such that it will place a jmp after the call, meaning when returning from the call it will jump over the data:

```
000071E7E8812020 push    r14
000071E7E8812022 push    rbx
000071E7E8812023 push    rax
000071E7E8812024 call    cs:off_71E7E881202C             ; __bionic_atfork_run_prepare(void)
000071E7E881202A jmp     short loc_71E7E8812034
000071E7E881202A ; ---------------------------------------------------------------------------
000071E7E881202C off_71E7E881202C dq offset _Z27__bionic_atfork_run_preparev
000071E7E881202C                                         ; DATA XREF: debug029:000071E7E8812024↑r
000071E7E881202C                                         ; __bionic_atfork_run_prepare(void)
000071E7E8812034 ; ---------------------------------------------------------------------------
000071E7E8812034
000071E7E8812034 loc_71E7E8812034:                       ; CODE XREF: debug029:000071E7E881202A↑j
000071E7E8812034 jmp     cs:off_71E7E881203A
000071E7E8812034 ; ---------------------------------------------------------------------------
000071E7E881203A off_71E7E881203A dq offset loc_71E7E74849F9
```