### PR TITLE
fix shared_cache file path iphoneos < 15.

### DIFF
--- a/builtin-plugin/SymbolResolver/macho/shared_cache_ctx.cpp
+++ b/builtin-plugin/SymbolResolver/macho/shared_cache_ctx.cpp
@@ -63,8 +63,9 @@ int shared_cache_load_symbols(shared_cache_ctx_t *ctx) {
     localSymbolsOffset = ctx->mmap_shared_cache->localSymbolsOffset;
   } else {
     // iphoneos < 15.0, which has no .symbols file
-    auto mmapSharedCacheMng = new MmapFileManager(shared_cache_symbols_path);
-
+    // auto mmapSharedCacheMng = new MmapFileManager(shared_cache_symbols_path);
+    // iphoneos < 15.0, which has no .symbols file, whether should use `shared_cache_path` without `.symbols` suffix ??? 
+    auto mmapSharedCacheMng = new MmapFileManager(shared_cache_path);
     auto runtime_shared_cache = ctx->runtime_shared_cache;
     uint64_t mmap_length = runtime_shared_cache->localSymbolsSize;
     uint64_t mmap_offset = runtime_shared_cache->localSymbolsOffset;


### PR DESCRIPTION
iphoneos < 15.0, which has no .symbols file, whether should use `shared_cache_path` without `.symbols` suffix ?